### PR TITLE
Using getUTCDate() instead of getUTCDay() as that's day of week

### DIFF
--- a/jquery-twitter-feed.js
+++ b/jquery-twitter-feed.js
@@ -91,7 +91,7 @@ DEALINGS IN THE SOFTWARE.
             } else if (dateDiff < hours) {
                 return dateDiff + " hours ago";
             } else {
-                return months[date.getUTCMonth()] + " " + date.getUTCDay() + " '" + (date.getUTCFullYear() + "").substring(2);
+                return months[date.getUTCMonth()] + " " + date.getUTCDate() + " '" + (date.getUTCFullYear() + "").substring(2);
             }
         };
 


### PR DESCRIPTION
When showing the full date, the day displayed was actually the day of the week instead of the day of the month.
